### PR TITLE
improvement: only call cleartab just before we really put it back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 os: linux
 
@@ -31,7 +31,7 @@ env:
     - LD_LIBRARY_PATH=$LUAJIT_LIB:$LD_LIBRARY_PATH
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.13.6
+    - NGINX_VERSION=1.21.4
 
 install:
     - sudo cpanm --notest Test::Nginx > build.log 2>&1 || (cat build.log && exit 1)

--- a/lib/tablepool.lua
+++ b/lib/tablepool.lua
@@ -44,11 +44,6 @@ function _M.release(tag, obj, noclear)
         pool[0] = 0
     end
 
-    if not noclear then
-        setmetatable(obj, nil)
-        cleartab(obj)
-    end
-
     do
         local cnt = pool.c + 1
         if cnt >= 20000 then
@@ -65,6 +60,11 @@ function _M.release(tag, obj, noclear)
     if len > max_pool_size then
         -- discard it simply
         return
+    end
+
+    if not noclear then
+        setmetatable(obj, nil)
+        cleartab(obj)
     end
 
     pool[len] = obj


### PR DESCRIPTION
We should only call cleartab() just before we really put it back